### PR TITLE
Bump version to 3.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ group = com.enonic.app
 projectName = logbrowser
 appName = com.enonic.app.logbrowser
 xpVersion = 8.0.0-B4
-version=2.1.0-SNAPSHOT
+version=3.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary

Branch out the XP 7 maintenance line and bump master to next-major SNAPSHOT, mirroring the convention used in [`enonic/app-booster`](https://github.com/enonic/app-booster).

- Bump `version` in `gradle.properties` from `2.1.0-SNAPSHOT` → `3.0.0-SNAPSHOT`.
- Add `releaseBranch:` block to `.github/workflows/enonic-gradle.yml` listing both `master` and `2.x` so release tooling recognizes both branches.

A maintenance branch [`2.x`](https://github.com/enonic/app-logbrowser/tree/2.x) was created from `272e9c3` (the post-`v2.0.0` SNAPSHOT-bump commit) to host XP 7 maintenance work; its `gradle.properties` stays at `2.1.0-SNAPSHOT`. A companion PR against `2.x` adds the same `releaseBranch:` block (required so pushes to `2.x` are recognized as release-branch builds — the action reads the workflow file from the branch's own checkout).

## Test plan

- [ ] CI runs green on this branch
- [ ] After merge to `master`: `./gradlew clean build` from `master` is green