### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -1,0 +1,29 @@
+name: Gradle Build
+
+on: [ push ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.build-and-publish.outputs.release }}
+    steps:
+      - id: build-and-publish
+        uses: enonic/release-tools/build-and-publish@master
+        with:
+          repoUser: ci
+          repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
+
+  release:
+    runs-on: ubuntu-latest
+
+    needs: build
+    if: needs.build.outputs.release == 'true'
+
+    steps:
+      - uses: enonic/release-tools/release@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Companion PR to the master-side bump (#75). Adds `.github/workflows/enonic-gradle.yml` to the new `2.x` maintenance branch with a `releaseBranch:` block listing both `master` and `2.x`, so pushes to `2.x` are recognized as release-branch builds — the `enonic/release-tools/build-and-publish` action reads `releaseBranch:` from the branch's own checkout, so the config has to live on `2.x` itself.

The `2.x` branch was created from `272e9c3` (the post-`v2.0.0` SNAPSHOT-bump commit). At that SHA the workflow file did not yet exist on the repo, so this PR creates it rather than editing it. No version bump and no other master-side changes are included — those are master-only per [`enonic/app-booster`](https://github.com/enonic/app-booster)'s reference pattern.

## Test plan

- [ ] CI run on `2.x` after merge classifies the branch as a release branch
- [ ] Maintenance branch `gradle.properties` stays at `2.1.0-SNAPSHOT`