### PR TITLE
Drop adminLib.getAssetsUri call #77

### DIFF
--- a/src/main/resources/admin/tools/logbrowser/logbrowser.html
+++ b/src/main/resources/admin/tools/logbrowser/logbrowser.html
@@ -91,10 +91,6 @@
 </div>
 
 <script type="text/javascript">
-    var CONFIG = {
-        portalAssetsUrl: '{{adminUiAssetsUrl}}',
-        appId: 'logbrowser'
-    };
     var SVC_URL = '{{svcUrl}}';
 </script>
 <script type="text/javascript" src="{{assetsUri}}/js/jquery-3.4.1.min.js"></script>

--- a/src/main/resources/admin/tools/logbrowser/logbrowser.js
+++ b/src/main/resources/admin/tools/logbrowser/logbrowser.js
@@ -1,13 +1,11 @@
 var mustache = require('/lib/mustache');
 var portalLib = require('/lib/xp/portal');
-var adminLib = require('/lib/xp/admin');
 
 exports.get = function (req) {
     var view = resolve('./logbrowser.html');
 
     var svcUrl = portalLib.serviceUrl({service: 'logbrowser'});
     var params = {
-        adminUiAssetsUrl: adminLib.getAssetsUri(),
         assetsUri: portalLib.assetUrl({path: ""}),
         svcUrl: svcUrl
     };


### PR DESCRIPTION
Closes #77

## Summary

Under XP 8, `/lib/xp/admin` no longer exposes `getAssetsUri`. The Log Browser admin tool called it from `logbrowser.js`, so every page render returned HTTP 500 with `TypeError: adminLib.getAssetsUri is not a function`.

The value only flowed into a single template slot — `CONFIG.portalAssetsUrl` in the rendered HTML — and `CONFIG` is not referenced by `logbrowser-tool.js` or any other client code. The whole config block was dead.

## What changed

- Drop `var adminLib = require('/lib/xp/admin');` and the `adminUiAssetsUrl: adminLib.getAssetsUri()` param.
- Drop the matching dead `var CONFIG = { portalAssetsUrl: ..., appId: ... };` block from `logbrowser.html`.

## E2E verified

Built against the app's declared `xpVersion=8.0.0-B4` and deployed into a fresh `xp-distro` install (`8.0.0-B4`):

- Bundle reaches ACTIVE: `Started application com.enonic.app.logbrowser bundle 119`
- Admin tool `/admin/com.enonic.app.logbrowser/logbrowser` — `HTTP 200`, 4117 bytes of expected HTML, asset URLs (`/_/asset/...`) resolve `HTTP 200`.
- Service POST `action=end` — `HTTP 200` with real log lines in JSON.
- WebSocket GET — `HTTP 204` (expected when no `Upgrade` header).
- No `ERROR`/`Exception` lines attributable to the bundle after the fix.