### PR TITLE
Migrate to lib-asset #79

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 repositories {
     mavenLocal()
     mavenCentral()
-    xp.enonicRepo()
+    xp.enonicRepo('dev')
 }
 
 dependencies {
@@ -16,5 +16,6 @@ dependencies {
     include xplibs.portal
     include xplibs.websocket
     include xplibs.admin
+    include "com.enonic.lib:lib-asset:2.0.0-SNAPSHOT"
     include "com.enonic.lib:lib-mustache:2.1.1"
 }

--- a/src/main/resources/admin/tools/logbrowser/logbrowser.js
+++ b/src/main/resources/admin/tools/logbrowser/logbrowser.js
@@ -1,12 +1,13 @@
 var mustache = require('/lib/mustache');
 var portalLib = require('/lib/xp/portal');
+var assetLib = require('/lib/enonic/asset');
 
 exports.get = function (req) {
     var view = resolve('./logbrowser.html');
 
     var svcUrl = portalLib.serviceUrl({service: 'logbrowser'});
     var params = {
-        assetsUri: portalLib.assetUrl({path: ""}),
+        assetsUri: assetLib.assetUrl({path: ""}),
         svcUrl: svcUrl
     };
 

--- a/src/main/resources/admin/tools/logbrowser/logbrowser.yaml
+++ b/src/main/resources/admin/tools/logbrowser/logbrowser.yaml
@@ -3,3 +3,5 @@ title: "Log Browser"
 description: "Browse and search the log"
 allow:
   - "role:system.admin"
+apis:
+  - "asset"


### PR DESCRIPTION
## Summary

`portal.assetUrl` is deprecated in lib-portal (`Use libAsset or libStatic instead. This function will be removed in future versions.`). Swap the admin tool's call to `lib-asset.assetUrl` and whitelist the `asset` API on the admin tool descriptor so the bundled asset endpoint is mounted.

The admin tool is the only context in this app, which is a supported context for lib-asset.

### Changes

- `build.gradle` — add `com.enonic.lib:lib-asset:2.0.0-SNAPSHOT` and switch `xp.enonicRepo()` → `xp.enonicRepo('dev')` so the SNAPSHOT resolves.
- `src/main/resources/admin/tools/logbrowser/logbrowser.yaml` — add `apis: ["asset"]`.
- `src/main/resources/admin/tools/logbrowser/logbrowser.js` — replace `portalLib.assetUrl(...)` with `assetLib.assetUrl(...)` via `require('/lib/enonic/asset')`.

Closes #79

## Test plan

- [x] `./gradlew build --refresh-dependencies` clean.
- [x] Bundle reaches ACTIVE in an XP 8.0.0-SNAPSHOT runtime (`Started application com.enonic.app.logbrowser bundle 117`).
- [x] `GET /admin/com.enonic.app.logbrowser/logbrowser` returns 200 with HTML and `{{assetsUri}}` rendered as `/admin/com.enonic.app.logbrowser/logbrowser/_/com.enonic.app.logbrowser:asset/<fingerprint>`.
- [x] CSS, JS, jQuery, and PNG assets under that path all return 200 with correct content types and sizes.
- [x] No errors or warnings in the server log (apart from the unrelated Nashorn ScriptEngineFactory warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)