### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,10 +12,10 @@ repositories {
 
 dependencies {
     implementation xplibs.api.script
-    include 'ch.qos.logback:logback-classic:1.5.32'
+    include libs.logback.classic
     include xplibs.portal
     include xplibs.websocket
     include xplibs.admin
-    include "com.enonic.lib:lib-asset:2.0.0-SNAPSHOT"
-    include "com.enonic.lib:lib-mustache:2.1.1"
+    include libs.lib.asset
+    include libs.lib.mustache
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,9 @@
+[versions]
+asset = "2.0.0-SNAPSHOT"
+logback-classic = "1.5.32"
+mustache = "2.1.1"
+
+[libraries]
+lib-asset = { module = "com.enonic.lib:lib-asset", version.ref = "asset" }
+lib-mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "mustache" }
+logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback-classic" }


### PR DESCRIPTION
## Summary

Move the three pinned dependency versions out of `build.gradle` and into a new `gradle/libs.versions.toml`. The migration is pin-for-pin; no versions were bumped. Resolved `runtimeClasspath` is byte-identical to master.

Conventions adopted (matching the dominant style in neighbouring catalogs in the tree):

- Lowercase, hyphen-separated keys (`logback-classic`, `lib-asset`).
- `[versions]` and `[libraries]` blocks each sorted alphabetically.
- Every library uses `version.ref`; no inline `version = "x.y"`.
- `xpVersion` left in `gradle.properties` — not part of the catalog.
- `xplibs.*` accessors and `${xpVersion}`-templated `com.enonic.xp:*` deps are untouched.

## Catalog content

```toml
[versions]
asset = "2.0.0-SNAPSHOT"
logback-classic = "1.5.32"
mustache = "2.1.1"

[libraries]
lib-asset = { module = "com.enonic.lib:lib-asset", version.ref = "asset" }
lib-mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "mustache" }
logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback-classic" }
```

## Verified

- `./gradlew build --refresh-dependencies` — green locally.
- `./gradlew dependencies --configuration runtimeClasspath` — identical before/after.