### PR TITLE
GraalJS Compatibility #92

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,21 +22,12 @@ dependencies {
     testImplementation "com.enonic.xp:testing:${xpVersion}"
     testImplementation 'org.junit.jupiter:junit-jupiter:6.1.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 test {
     useJUnitPlatform()
 }
 
-def testGraalJs = tasks.register('testGraalJs', Test) {
-    group = 'verification'
-    description = 'Runs tests with the GraalJS script engine.'
-    useJUnitPlatform()
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
-    systemProperty 'xp.script-engine', 'GraalJS'
-    shouldRunAfter test
+xp {
+    scriptEngines = ['Nashorn', 'GraalJS']
 }
-
-check.dependsOn testGraalJs

--- a/build.gradle
+++ b/build.gradle
@@ -18,4 +18,25 @@ dependencies {
     include xplibs.admin
     include libs.lib.asset
     include libs.lib.mustache
+
+    testImplementation "com.enonic.xp:testing:${xpVersion}"
+    testImplementation 'org.junit.jupiter:junit-jupiter:6.1.1'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
+
+test {
+    useJUnitPlatform()
+}
+
+def testGraalJs = tasks.register('testGraalJs', Test) {
+    group = 'verification'
+    description = 'Runs tests with the GraalJS script engine.'
+    useJUnitPlatform()
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    systemProperty 'xp.script-engine', 'GraalJS'
+    shouldRunAfter test
+}
+
+check.dependsOn testGraalJs

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@
 group = com.enonic.app
 projectName = logbrowser
 appName = com.enonic.app.logbrowser
-xpVersion = 8.0.2
+xpVersion = 8.1.0-SNAPSHOT
 version=3.0.0-SNAPSHOT

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.enonic.xp.settings' version '4.1.0'
+    id 'com.enonic.xp.settings' version '4.2.0'
 }
 
 rootProject.name = projectName

--- a/src/main/resources/lib/logfile.js
+++ b/src/main/resources/lib/logfile.js
@@ -2,12 +2,12 @@ var logTailManager = __.newBean('com.enonic.app.logbrowser.LogTailManager');
 
 exports.getLines = function (params) {
     var bean = __.newBean('com.enonic.app.logbrowser.LogFileHandler');
-    bean.lineCount = params.lineCount;
-    bean.from = params.from;
-    bean.action = params.action || 'forward';
-    bean.search = params.search;
-    bean.regex = params.regex;
-    bean.matchCase = params.matchCase;
+    bean.setLineCount(__.nullOrValue(params.lineCount));
+    bean.setFrom(__.nullOrValue(params.from));
+    bean.setAction(params.action || 'forward');
+    bean.setSearch(__.nullOrValue(params.search));
+    bean.setRegex(__.nullOrValue(params.regex));
+    bean.setMatchCase(__.nullOrValue(params.matchCase));
 
     return __.toNativeObject(bean.getLines());
 };

--- a/src/test/java/com/enonic/app/logbrowser/LogFileScriptTest.java
+++ b/src/test/java/com/enonic/app/logbrowser/LogFileScriptTest.java
@@ -1,0 +1,23 @@
+package com.enonic.app.logbrowser;
+
+import java.nio.file.Files;
+
+import com.enonic.xp.testing.ScriptRunnerSupport;
+
+public class LogFileScriptTest
+    extends ScriptRunnerSupport
+{
+    @Override
+    protected void initialize()
+        throws Exception
+    {
+        super.initialize();
+        System.setProperty( "xp.home", Files.createTempDirectory( "logbrowser-test-home" ).toString() );
+    }
+
+    @Override
+    public String getScriptTestFile()
+    {
+        return "/lib/logfile-test.js";
+    }
+}

--- a/src/test/resources/lib/logfile-test.js
+++ b/src/test/resources/lib/logfile-test.js
@@ -1,0 +1,23 @@
+var logfileLib = require('/lib/logfile');
+var assert = require('/lib/xp/testing');
+
+exports.testGetLinesWithAllParams = function () {
+    var result = logfileLib.getLines({
+        lineCount: 10,
+        from: 0,
+        action: 'forward',
+        search: 'error',
+        regex: false,
+        matchCase: true
+    });
+
+    assert.assertNotNull(result);
+    assert.assertJsonEquals({size: 0, lines: []}, result);
+};
+
+exports.testGetLinesWithMissingOptionalParams = function () {
+    var result = logfileLib.getLines({});
+
+    assert.assertNotNull(result);
+    assert.assertJsonEquals({size: 0, lines: []}, result);
+};


### PR DESCRIPTION
Fixes #92

## What

`exports.getLines` in `lib/logfile.js` set its six `LogFileHandler` properties
Nashorn-style. GraalJS does not map `bean.foo = x` to `setFoo(x)` — the shorthand
went away with nashorn-compat mode (enonic/xp#9236) — and `LogFileHandler` exposes
only setters, no public fields, so there is no field-write fallback:

```
TypeError: writeMember (lineCount) on com.enonic.app.logbrowser.LogFileHandler
failed due to: Unknown identifier: lineCount
```

All six writes now call the setters. The five values read straight off `params`
that may be `undefined` (`lineCount`, `from`, `search`, `regex`, `matchCase`) go
through `__.nullOrValue(...)` so an absent parameter reaches the setter as `null`
rather than `undefined` — the property form used to hide that. `action` is not
wrapped because `params.action || 'forward'` can never be undefined.

## Tested on both engines

This repository had **no JS-executing tests**, so nothing reached these sites on
either engine. Added a test (`LogFileScriptTest` + `lib/logfile-test.js`) that
exercises `getLines` — once with all params, once with an empty object (the
`nullOrValue` path). It runs once per script engine: Nashorn via `test` (the
platform default) and GraalJS via `testGraalJs`, both wired into `check`,
mirroring `gradle/js-tests.gradle` in the platform.

Verified locally against a build of enonic/xp#12198 (`publishToMavenLocal`):

```
test         2 tests, 0 failed
testGraalJs  2 tests, 0 failed
```

Before the fix, `testGraalJs` failed 2/2 with the `TypeError` above (failing on the
first write, `lineCount`) while `test` stayed green — exactly the divergence the
second engine exists to catch.

## Note on `xpVersion`

The bump to `8.1.0-SNAPSHOT` (and `enonicRepo('dev')`, already present here) is
required by `testGraalJs`, not by the setter fix — the fix alone is green on
Nashorn under 8.0.2.

`ScriptRunnerSupport.findTestNames()` used to close the script executor before the
dynamic tests ran, so on GraalJS every test failed with
`IllegalStateException: The Context is already closed` regardless of this app's
code. That is fixed in enonic/xp#12198 ("Keep the script executor alive through JS
test discovery"), so **CI `testGraalJs` will stay red until enonic/xp#12198 is
merged and a fresh `8.1.0-SNAPSHOT` is published** — the snapshot currently on
`repo.enonic.com/dev` still carries the old `ScriptRunnerSupport`.

Holding this as a **draft** until then.

Reference implementation: enonic/lib-sql#154.
